### PR TITLE
Added post process file to disable ENABLE_BITCODE on IOS build.

### DIFF
--- a/Assets/Placenote/Editor/PostBuildTrigger.cs
+++ b/Assets/Placenote/Editor/PostBuildTrigger.cs
@@ -1,0 +1,36 @@
+﻿using UnityEngine;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.iOS.Xcode;
+using System.IO;
+#if UNITY_2018_1_OR_NEWER
+using UnityEditor.iOS.Xcode.Extensions;
+#endif
+
+public class PostBuildTrigger : MonoBehaviour 
+{
+    [PostProcessBuild (500)]
+    public static void OnPostprocessBuild (BuildTarget target, string pathToBuiltProject)
+    {
+        #if UNITY_IOS
+        Debug.Log ("Post Processing IOS Build...");
+        //EmbedFrameworks
+        var projPath = PBXProject.GetPBXProjectPath (pathToBuiltProject);
+        var proj = new PBXProject ();
+        proj.ReadFromString (File.ReadAllText (projPath));
+        var targetGuid = proj.TargetGuidByName ("Unity-iPhone");
+        // EmbedFrameworks cannot be added in Unity 5.6.5
+        #if UNITY_2018_1_OR_NEWER
+        const string defaultLocationInProj = "Plugins/iOS";
+        const string coreFrameworkName = "Placenote.framework";
+        var framework = Path.Combine(defaultLocationInProj, coreFrameworkName);
+        var fileGuid = proj.AddFile(framework, "Frameworks/Placenote/" + framework, PBXSourceTree.Sdk);
+        PBXProjectExtensions.AddFileToEmbedFrameworks(proj, targetGuid, fileGuid);
+        proj.SetBuildProperty(targetGuid, "LD_RUNPATH_SEARCH_PATHS", "$(inherited) @executable_path/Frameworks");
+        #endif
+        proj.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");
+        proj.WriteToFile (projPath); 
+        //EmbedFrameworks end
+        #endif
+    }
+}

--- a/Assets/Placenote/Editor/PostBuildTrigger.cs.meta
+++ b/Assets/Placenote/Editor/PostBuildTrigger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 76fcb9fe865c94d6d8998315ead7a15f
+timeCreated: 1527701843
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Placenote/LibPlacenote/FeaturesVisualizer.cs
+++ b/Assets/Placenote/LibPlacenote/FeaturesVisualizer.cs
@@ -15,9 +15,12 @@ public class FeaturesVisualizer : MonoBehaviour, PlacenoteListener
 	void Awake ()
 	{
 		sInstance = this;
+	}
 
-		// This is required for OnPose and OnStatusChange to be triggered
-		LibPlacenote.Instance.RegisterListener (this);
+	void Start ()
+	{
+        // This is required for OnPose and OnStatusChange to be triggered
+        LibPlacenote.Instance.RegisterListener (this);
 	}
 
 	void Update ()

--- a/Assets/Placenote/LibPlacenote/LibPlacenote.cs
+++ b/Assets/Placenote/LibPlacenote/LibPlacenote.cs
@@ -313,7 +313,6 @@ public class LibPlacenote : MonoBehaviour
 	}
 
 
-
 	/// <summary>
 	/// Raises the initialized event that indicates the status of the <see cref="PNInitialize"/> call
 	/// </summary>
@@ -352,7 +351,7 @@ public class LibPlacenote : MonoBehaviour
 		initParams.appBasePath = Application.streamingAssetsPath + "/Placenote";
 		initParams.mapPath = Application.persistentDataPath;
 
-    #if !UNITY_EDITOR
+        	#if !UNITY_EDITOR
 		PNInitialize (ref initParams, OnInitialized, IntPtr.Zero);
 		#endif
 	}
@@ -1038,9 +1037,6 @@ public class LibPlacenote : MonoBehaviour
 		PNFeaturePointUnity[] map = new PNFeaturePointUnity [1];
 		#if !UNITY_EDITOR
 		lmSize = PNGetAllLandmarks (map, 0);
-
-		#else
-
 		#endif
 
 		if (lmSize == 0) {
@@ -1051,8 +1047,6 @@ public class LibPlacenote : MonoBehaviour
 		#if !UNITY_EDITOR
 		Array.Resize (ref map, lmSize);
 		PNGetAllLandmarks (map, lmSize);
-
-
 		#endif
 
 		return map;


### PR DESCRIPTION
Also added Placenote.framework to list of embed frameworks automatically (Only for Unity 2018 and newer). 

Finally, moved FeaturesVisualizer Listener from Awake to Start.